### PR TITLE
Outbox Events

### DIFF
--- a/orders-service/src/main/java/dev/sndsprfct/orders/constant/OutboxEventStatus.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/constant/OutboxEventStatus.java
@@ -1,0 +1,5 @@
+package dev.sndsprfct.orders.constant;
+
+public enum OutboxEventStatus {
+    PENDING, SENT
+}

--- a/orders-service/src/main/java/dev/sndsprfct/orders/constant/OutboxEventType.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/constant/OutboxEventType.java
@@ -1,0 +1,5 @@
+package dev.sndsprfct.orders.constant;
+
+public enum OutboxEventType {
+    ORDER_CREATED
+}

--- a/orders-service/src/main/java/dev/sndsprfct/orders/dto/ErrorDetails.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/dto/ErrorDetails.java
@@ -1,8 +1,5 @@
 package dev.sndsprfct.orders.dto;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-
 import java.time.Instant;
 
 public record ErrorDetails(Instant timestamp, int status, String error) {

--- a/orders-service/src/main/java/dev/sndsprfct/orders/entity/Order.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/entity/Order.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 @Table(schema = "orders", name = "orders")
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @Setter
 @Getter
 public class Order {

--- a/orders-service/src/main/java/dev/sndsprfct/orders/entity/OrderItem.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/entity/OrderItem.java
@@ -1,5 +1,6 @@
 package dev.sndsprfct.orders.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,6 +32,7 @@ public class OrderItem {
 
     @ManyToOne
     @JoinColumn(name = "order_id")
+    @JsonIgnore
     private Order order;
 
     @ManyToOne

--- a/orders-service/src/main/java/dev/sndsprfct/orders/entity/outbox/OutboxEvent.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/entity/outbox/OutboxEvent.java
@@ -15,6 +15,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -46,6 +48,7 @@ public class OutboxEvent {
     private OutboxEventStatus status = OutboxEventStatus.PENDING;
 
     @Column(name = "payload")
+    @JdbcTypeCode(SqlTypes.JSON)
     private String payload;
 
     @Override

--- a/orders-service/src/main/java/dev/sndsprfct/orders/entity/outbox/OutboxEvent.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/entity/outbox/OutboxEvent.java
@@ -1,0 +1,64 @@
+package dev.sndsprfct.orders.entity.outbox;
+
+import dev.sndsprfct.orders.constant.OutboxEventStatus;
+import dev.sndsprfct.orders.constant.OutboxEventType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Entity
+@Table(schema = "outbox", name = "outbox_events")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+public class OutboxEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "created_at")
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    private OutboxEventType type;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private OutboxEventStatus status = OutboxEventStatus.PENDING;
+
+    @Column(name = "payload")
+    private String payload;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OutboxEvent that = (OutboxEvent) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+}

--- a/orders-service/src/main/java/dev/sndsprfct/orders/exception/OutboxEventPayloadWasNotSerializedException.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/exception/OutboxEventPayloadWasNotSerializedException.java
@@ -1,0 +1,7 @@
+package dev.sndsprfct.orders.exception;
+
+public class OutboxEventPayloadWasNotSerializedException extends RuntimeException {
+    public OutboxEventPayloadWasNotSerializedException(Exception e) {
+        super(e);
+    }
+}

--- a/orders-service/src/main/java/dev/sndsprfct/orders/repository/OutboxEventRepository.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/repository/OutboxEventRepository.java
@@ -1,0 +1,7 @@
+package dev.sndsprfct.orders.repository;
+
+import dev.sndsprfct.orders.entity.outbox.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+}

--- a/orders-service/src/main/java/dev/sndsprfct/orders/service/OrderProcessingService.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/service/OrderProcessingService.java
@@ -1,0 +1,36 @@
+package dev.sndsprfct.orders.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.sndsprfct.orders.constant.OutboxEventType;
+import dev.sndsprfct.orders.entity.Order;
+import dev.sndsprfct.orders.entity.outbox.OutboxEvent;
+import dev.sndsprfct.orders.exception.OutboxEventPayloadWasNotSerializedException;
+import dev.sndsprfct.orders.repository.OrderRepository;
+import dev.sndsprfct.orders.repository.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderProcessingService {
+
+    private final OrderRepository orderRepository;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public Long processOrderCreation(Order order) {
+        Order savedOrder = orderRepository.save(order);
+        OutboxEvent outboxEvent = new OutboxEvent();
+        outboxEvent.setType(OutboxEventType.ORDER_CREATED);
+        try {
+            outboxEvent.setPayload(objectMapper.writeValueAsString(savedOrder));
+        } catch (JsonProcessingException e) {
+            throw new OutboxEventPayloadWasNotSerializedException(e);
+        }
+        outboxEventRepository.save(outboxEvent);
+        return savedOrder.getId();
+    }
+}

--- a/orders-service/src/main/java/dev/sndsprfct/orders/service/OrderService.java
+++ b/orders-service/src/main/java/dev/sndsprfct/orders/service/OrderService.java
@@ -20,13 +20,14 @@ public class OrderService {
     private final ProductService productService;
     private final OrderRepository orderRepository;
     private final OrderMapper orderMapper;
+    private final OrderProcessingService orderProcessingService;
 
     public OrderCreatedResponseDto createOrder(OrderCreationRequestDto orderCreationRequestDto) {
         List<Product> products = productService.checkProductsAvailability(orderCreationRequestDto.productsAmountByProductId().keySet());
         validateOrderIdempotencyKey(orderCreationRequestDto);
         Order order = orderMapper.map(orderCreationRequestDto, products);
-        Order createdOrder = orderRepository.save(order);
-        return new OrderCreatedResponseDto(createdOrder.getId());
+        Long createdOrderId = orderProcessingService.processOrderCreation(order);
+        return new OrderCreatedResponseDto(createdOrderId);
     }
 
     public List<OrderResponseDto> findCustomerOrders(Long customerId) {

--- a/orders-service/src/main/resources/db/migration/V2025.09.26_1__outbox_events_table.sql
+++ b/orders-service/src/main/resources/db/migration/V2025.09.26_1__outbox_events_table.sql
@@ -1,0 +1,11 @@
+
+CREATE SCHEMA outbox;
+
+CREATE TABLE outbox.outbox_events (
+    id bigserial PRIMARY KEY,
+    created_at timestamp NOT NULL DEFAULT NOW(),
+    type varchar NOT NULL CHECK (type in ('ORDER_CREATED')),
+    status varchar NOT NULL CHECK (status in ('PENDING', 'SENT')) DEFAULT 'PENDING',
+    update_at timestamp,
+    payload jsonb NOT NULL
+);

--- a/orders-service/src/main/resources/db/migration/V2025.09.26_1__outbox_events_table.sql
+++ b/orders-service/src/main/resources/db/migration/V2025.09.26_1__outbox_events_table.sql
@@ -6,6 +6,6 @@ CREATE TABLE outbox.outbox_events (
     created_at timestamp NOT NULL DEFAULT NOW(),
     type varchar NOT NULL CHECK (type in ('ORDER_CREATED')),
     status varchar NOT NULL CHECK (status in ('PENDING', 'SENT')) DEFAULT 'PENDING',
-    update_at timestamp,
+    updated_at timestamp,
     payload jsonb NOT NULL
 );

--- a/orders-service/src/test/java/dev/sndsprfct/orders/unit/mapper/OrderMapperTest.java
+++ b/orders-service/src/test/java/dev/sndsprfct/orders/unit/mapper/OrderMapperTest.java
@@ -1,0 +1,71 @@
+package dev.sndsprfct.orders.unit.mapper;
+
+import dev.sndsprfct.orders.dto.request.OrderCreationRequestDto;
+import dev.sndsprfct.orders.dto.response.OrderResponseDto;
+import dev.sndsprfct.orders.entity.Order;
+import dev.sndsprfct.orders.entity.OrderItem;
+import dev.sndsprfct.orders.entity.Product;
+import dev.sndsprfct.orders.mapper.OrderMapper;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.Instant;
+import java.util.List;
+
+import static dev.sndsprfct.orders.utils.TestConstants.TEST_PRODUCT1_NAME;
+import static dev.sndsprfct.orders.utils.TestConstants.TEST_PRODUCT1_PRICE;
+import static dev.sndsprfct.orders.utils.TestConstants.TEST_PRODUCT2_NAME;
+import static dev.sndsprfct.orders.utils.TestConstants.TEST_PRODUCT2_PRICE;
+import static dev.sndsprfct.orders.utils.TestConstants.getOrderCreationRequestDto;
+import static dev.sndsprfct.orders.utils.TestConstants.getOrderResponseDto;
+import static dev.sndsprfct.orders.utils.TestConstants.getProduct1;
+import static dev.sndsprfct.orders.utils.TestConstants.getProduct2;
+import static dev.sndsprfct.orders.utils.TestConstants.getTestOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class OrderMapperTest {
+
+    private final OrderMapper orderMapper = Mappers.getMapper(OrderMapper.class);
+
+    @Test
+    void testOrderEntityToOrderResponseDtoMapping() {
+        // given
+        Order order = getTestOrder();
+        OrderResponseDto orderResponseDto = getOrderResponseDto();
+
+
+        // when
+        OrderResponseDto map = orderMapper.map(order);
+
+        // then
+        assertThat(map)
+                .usingRecursiveComparison()
+                .ignoringFieldsOfTypes(Instant.class)
+                .isEqualTo(orderResponseDto);
+    }
+
+    @Test
+    void testOrderCreationRequestDtoToOrderEntityMapping() {
+        // given
+        OrderCreationRequestDto orderCreationRequestDto = getOrderCreationRequestDto();
+        Order expectedOrder = getTestOrder();
+        expectedOrder.setId(null);
+        List<Product> products = List.of(getProduct1(), getProduct2());
+
+        // when
+        Order order = orderMapper.map(orderCreationRequestDto, products);
+
+        // then
+        assertThat(order)
+                .usingRecursiveComparison()
+                .ignoringFieldsOfTypes(Instant.class, OrderItem.class)
+                .isEqualTo(expectedOrder);
+
+        assertThat(order.getOrderItems())
+                .extracting("product.name", "quantity", "unitPrice")
+                .containsExactlyInAnyOrder(
+                        tuple(TEST_PRODUCT1_NAME, 2, TEST_PRODUCT1_PRICE),
+                        tuple(TEST_PRODUCT2_NAME, 2, TEST_PRODUCT2_PRICE));
+    }
+}

--- a/orders-service/src/test/java/dev/sndsprfct/orders/unit/service/OrderProcessingServiceTest.java
+++ b/orders-service/src/test/java/dev/sndsprfct/orders/unit/service/OrderProcessingServiceTest.java
@@ -1,0 +1,84 @@
+package dev.sndsprfct.orders.unit.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.sndsprfct.orders.constant.OutboxEventStatus;
+import dev.sndsprfct.orders.constant.OutboxEventType;
+import dev.sndsprfct.orders.entity.Order;
+import dev.sndsprfct.orders.entity.outbox.OutboxEvent;
+import dev.sndsprfct.orders.repository.OrderRepository;
+import dev.sndsprfct.orders.repository.OutboxEventRepository;
+import dev.sndsprfct.orders.service.OrderProcessingService;
+import dev.sndsprfct.orders.utils.TestConstants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderProcessingServiceTest {
+
+    @Captor
+    private ArgumentCaptor<OutboxEvent> outboxEventArgumentCaptor;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Spy
+    private ObjectMapper objectMapper;
+
+    {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @InjectMocks
+    private OrderProcessingService orderProcessingService;
+
+    @Test
+    void processOrderCreation() {
+        // given
+        Order testOrder = TestConstants.getTestOrder();
+        when(orderRepository.save(eq(testOrder)))
+                .thenReturn(testOrder.toBuilder().id(TestConstants.TEST_ORDER_ID).build());
+        OutboxEvent expectedOutboxEvent = OutboxEvent.builder()
+                .status(OutboxEventStatus.PENDING)
+                .type(OutboxEventType.ORDER_CREATED)
+                .build();
+
+        // when
+        Long orderId = orderProcessingService.processOrderCreation(testOrder);
+
+        // then
+        assertThat(orderId)
+                .isEqualTo(TestConstants.TEST_ORDER_ID);
+
+        verify(orderRepository).save(testOrder);
+        verify(outboxEventRepository).save(outboxEventArgumentCaptor.capture());
+        OutboxEvent capturedOutboxEvent = outboxEventArgumentCaptor.getValue();
+
+        assertThat(capturedOutboxEvent)
+                .usingRecursiveComparison()
+                .ignoringFieldsOfTypes(Instant.class)
+                .ignoringFields("payload")
+                .isEqualTo(expectedOutboxEvent);
+        assertThat(capturedOutboxEvent.getPayload())
+                .isNotBlank();
+    }
+
+
+}

--- a/orders-service/src/test/java/dev/sndsprfct/orders/utils/TestConstants.java
+++ b/orders-service/src/test/java/dev/sndsprfct/orders/utils/TestConstants.java
@@ -1,4 +1,4 @@
-package dev.sndsprfct.orders.mapper;
+package dev.sndsprfct.orders.utils;
 
 import dev.sndsprfct.orders.constant.OrderStatus;
 import dev.sndsprfct.orders.dto.request.OrderCreationRequestDto;
@@ -7,8 +7,6 @@ import dev.sndsprfct.orders.dto.response.OrderResponseDto;
 import dev.sndsprfct.orders.entity.Order;
 import dev.sndsprfct.orders.entity.OrderItem;
 import dev.sndsprfct.orders.entity.Product;
-import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -16,67 +14,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+public class TestConstants {
+    public static final Long TEST_ORDER_ID = 1L;
+    public static final Long TEST_CUSTOMER_ID = 1L;
+    public static final String TEST_DELIVERY_ADDRESS = "Delivery Address";
+    public static final UUID TEST_IDEMPOTENCY_KEY = UUID.randomUUID();
 
-class OrderMapperTest {
+    public static final Long TEST_PRODUCT1_ID = 1L;
+    public static final String TEST_PRODUCT1_NAME = "Test Product 1";
+    public static final Long TEST_PRODUCT1_PRICE = 100L;
 
-    private static final Long TEST_CUSTOMER_ID = 1L;
-    private static final String TEST_DELIVERY_ADDRESS = "Delivery Address";
-    private static final UUID TEST_IDEMPOTENCY_KEY = UUID.randomUUID();
+    public static final Long TEST_PRODUCT2_ID = 2L;
+    public static final String TEST_PRODUCT2_NAME = "Test Product 2";
+    public static final Long TEST_PRODUCT2_PRICE = 100L;
 
-    private static final Long TEST_PRODUCT1_ID = 1L;
-    private static final String TEST_PRODUCT1_NAME = "Test Product 1";
-    private static final Long TEST_PRODUCT1_PRICE = 100L;
-
-    private static final Long TEST_PRODUCT2_ID = 2L;
-    private static final String TEST_PRODUCT2_NAME = "Test Product 2";
-    private static final Long TEST_PRODUCT2_PRICE = 100L;
-
-    private final OrderMapper orderMapper = Mappers.getMapper(OrderMapper.class);
-
-    @Test
-    void testOrderEntityToOrderResponseDtoMapping() {
-        // given
-        Order order = getTestOrder();
-        OrderResponseDto orderResponseDto = getOrderResponseDto();
-
-
-        // when
-        OrderResponseDto map = orderMapper.map(order);
-
-        // then
-        assertThat(map)
-                .usingRecursiveComparison()
-                .ignoringFieldsOfTypes(Instant.class)
-                .isEqualTo(orderResponseDto);
-    }
-
-    @Test
-    void testOrderCreationRequestDtoToOrderEntityMapping() {
-        // given
-        OrderCreationRequestDto orderCreationRequestDto = getOrderCreationRequestDto();
-        Order expectedOrder = getTestOrder();
-        expectedOrder.setId(null);
-        List<Product> products = List.of(getProduct1(), getProduct2());
-
-        // when
-        Order order = orderMapper.map(orderCreationRequestDto, products);
-
-        // then
-        assertThat(order)
-                .usingRecursiveComparison()
-                .ignoringFieldsOfTypes(Instant.class, OrderItem.class)
-                .isEqualTo(expectedOrder);
-
-        assertThat(order.getOrderItems())
-                .extracting("product.name", "quantity", "unitPrice")
-                .containsExactlyInAnyOrder(
-                        tuple(TEST_PRODUCT1_NAME, 2, TEST_PRODUCT1_PRICE),
-                        tuple(TEST_PRODUCT2_NAME, 2, TEST_PRODUCT2_PRICE));
-    }
-
-    private OrderCreationRequestDto getOrderCreationRequestDto() {
+    public static OrderCreationRequestDto getOrderCreationRequestDto() {
         return new OrderCreationRequestDto(
                 1L,
                 TEST_IDEMPOTENCY_KEY,
@@ -84,7 +36,7 @@ class OrderMapperTest {
                 TEST_DELIVERY_ADDRESS);
     }
 
-    private OrderResponseDto getOrderResponseDto() {
+    public static OrderResponseDto getOrderResponseDto() {
         OrderItemResponseDto orderItemResponseDto1 = new OrderItemResponseDto(
                 TEST_PRODUCT1_ID,
                 TEST_PRODUCT1_ID,
@@ -107,7 +59,7 @@ class OrderMapperTest {
                 TEST_PRODUCT1_PRICE + TEST_PRODUCT2_PRICE);
     }
 
-    private Order getTestOrder() {
+    public static Order getTestOrder() {
         Product product1 = getProduct1();
         Product product2 = getProduct2();
 
@@ -136,7 +88,7 @@ class OrderMapperTest {
                 .build();
     }
 
-    private static Product getProduct2() {
+    public static Product getProduct2() {
         return Product.builder()
                 .id(TEST_PRODUCT2_ID)
                 .name(TEST_PRODUCT2_NAME)
@@ -145,7 +97,7 @@ class OrderMapperTest {
                 .build();
     }
 
-    private static Product getProduct1() {
+    public static Product getProduct1() {
         return Product.builder()
                 .id(TEST_PRODUCT1_ID)
                 .name(TEST_PRODUCT1_NAME)


### PR DESCRIPTION
When an app should save main entity (**Order** here) and send a message into a message broker it is better to use **Transactional Outbox Pattern** to avoid message disappearing.

Added logic allows to save message about new order creation into separate table **outbox.outbox_events** in the same transaction with order saving and send this message later using scheduler.